### PR TITLE
Fix parent_name deprecation in rails 6.1+

### DIFF
--- a/lib/funk_hands/railtie.rb
+++ b/lib/funk_hands/railtie.rb
@@ -42,7 +42,11 @@ module FunkHands
         bold = ->(text) { color[] ? "\001\e[1m\002#{text}\001\e[0m\002"    : text.to_s }
 
         separator = -> { red.(FunkHands.prompt_separator) }
-        name = app.class.parent_name.underscore
+        name = if app.class.respond_to? :module_parent_name # Rails 6
+          app.class.module_parent_name.underscore
+        else # Older Rails versions
+          app.class.parent_name.underscore
+        end
         colored_name = -> { blue.(name) }
 
         line = ->(pry) { "[#{bold.(pry.input_ring.size)}] " }


### PR DESCRIPTION
Replacing call to `parent_name` by `module_parent_name` to fix this
deprecation: https://github.com/rails/rails/blob/6-0-stable/activesupport/lib/active_support/core_ext/module/introspection.rb#L20-L26

Keep `parent_name` for older rails version.